### PR TITLE
Fix usage of CFLAGS_ARM32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ makecapk/lib/arm64-v8a/lib$(APPNAME).so : $(ANDROIDSRCS)
 
 makecapk/lib/armeabi-v7a/lib$(APPNAME).so : $(ANDROIDSRCS)
 	mkdir -p makecapk/lib/armeabi-v7a
-	$(CC_ARM32) $(CFLAGS) $(CFLAGS_ARM64) -o $@ $^ $(LDFLAGS)
+	$(CC_ARM32) $(CFLAGS) $(CFLAGS_ARM32) -o $@ $^ $(LDFLAGS)
 
 makecapk/lib/x86/lib$(APPNAME).so : $(ANDROIDSRCS)
 	mkdir -p makecapk/lib/x86


### PR DESCRIPTION
Had the same issue as #4, seems CFLAGS_ARM**64** was being used mistakenly for the ARM32 build instead of CFLAGS_ARM**32**, so I was getting the same 'java.lang.UnsatisfiedLinkError' (...`rawdrawtest.so" is 64-bit instead of 32-bit`)

This made the armeabi-v7a build run correctly on my OnePlus One.

Also just wanted to say, huge kudos for all of your work! This project brings a lot of encouragement for those of us who can't stand Android Studio :laughing: 
