### PR TITLE
Fix for Android 4.2 (API 17)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?><manifest xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android" package="org.yourorg.cnfgtest">
-    <uses-permission android:name="android.permission.SET_RELEASE_APP"/>
-    <application android:debuggable="true" android:hasCode="false" android:label="@string/app_name" android:theme="@android:style/Theme.NoTitleBar.Fullscreen"  tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon"  android:requestLegacyExternalStorage="true">
+    <application android:debuggable="true" android:hasCode="false" android:label="@string/app_name" android:theme="@android:style/Theme.NoTitleBar.Fullscreen"  tools:replace="android:icon,android:theme,android:allowBackup,label" android:icon="@mipmap/icon">
         <activity android:configChanges="keyboardHidden|orientation" android:name="android.app.NativeActivity">
             <meta-data android:name="android.app.lib_name" android:value="@string/lib_name"/>
             <intent-filter>

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,12 @@ RAWDRAWANDROID?=.
 RAWDRAWANDROIDSRCS=$(RAWDRAWANDROID)/android_native_app_glue.c
 SRC?=test.c
 #We've tested it with android version 24 and 29.
-ANDROIDVERSION?=29
+ANDROIDVERSION?=17
 #Default is to be strip down, but your app can override it.
 CFLAGS?=-ffunction-sections -Os -fdata-sections -Wall -fvisibility=hidden
 LDFLAGS?=-Wl,--gc-sections -s
-ANDROID_FULLSCREEN?=y
+ANDROID_FULLSCREEN?=n
+ANDROID_WITH_SENSOR?=n
 ADB?=adb
 UNAME := $(shell uname)
 
@@ -50,12 +51,15 @@ BUILD_TOOLS?=$(firstword $(wildcard $(ANDROIDSDK)/build-tools/*) )
 testsdk :
 	echo $(BUILD_TOOLS)
 
-CFLAGS+=-Os -DANDROID -DAPPNAME=\"$(APPNAME)\"
-ifeq (ANDROID_FULLSCREEN,y)
+CFLAGS+=-DANDROID -DAPPNAME=\"$(APPNAME)\"
+ifeq ($(ANDROID_FULLSCREEN),y)
 CFLAGS +=-DANDROID_FULLSCREEN
 endif
+ifeq ($(ANDROID_WITH_SENSOR),y)
+CFLAGS +=-DANDROID_WITH_SENSOR
+endif
 CFLAGS+= -I$(RAWDRAWANDROID)/rawdraw -I$(NDK)/sysroot/usr/include -I$(NDK)/sysroot/usr/include/android -fPIC -I$(RAWDRAWANDROID)
-LDFLAGS += -lm -L$(NDK)toolchains/llvm/prebuilt/$(OS_NAME)/sysroot/usr/lib/aarch64-linux-android/$(ANDROIDVERSION) -lGLESv3 -lEGL -landroid -llog
+LDFLAGS += -lm -L$(NDK)toolchains/llvm/prebuilt/$(OS_NAME)/sysroot/usr/lib/armv7a-linux-androideabi/$(ANDROIDVERSION) -lGLESv2 -lEGL -landroid -llog
 LDFLAGS += -shared -uANativeActivity_onCreate
 
 CC_ARM64:=$(NDK)/toolchains/llvm/prebuilt/$(OS_NAME)/bin/aarch64-linux-android$(ANDROIDVERSION)-clang
@@ -65,7 +69,8 @@ CC_x86_64=$(NDK)/toolchains/llvm/prebuilt/$(OS_NAME)/bin/x86_64-linux-android$(A
 AAPT:=$(BUILD_TOOLS)/aapt
 
 # Which binaries to build? NOTE: If you want to add to the number of supported releases, add to this line.
-TARGETS?=makecapk/lib/arm64-v8a/lib$(APPNAME).so #makecapk/lib/armeabi-v7a/lib$(APPNAME).so makecapk/lib/x86/lib$(APPNAME).so makecapk/lib/x86_64/lib$(APPNAME).so
+#TARGETS?=makecapk/lib/arm64-v8a/lib$(APPNAME).so #makecapk/lib/armeabi-v7a/lib$(APPNAME).so makecapk/lib/x86/lib$(APPNAME).so makecapk/lib/x86_64/lib$(APPNAME).so
+TARGETS?=makecapk/lib/armeabi-v7a/lib$(APPNAME).so
 
 CFLAGS_ARM64:=-m64
 CFLAGS_ARM32:=-mfloat-abi=softfp -m32

--- a/test.c
+++ b/test.c
@@ -10,7 +10,6 @@
 #include <asset_manager.h>
 #include <asset_manager_jni.h>
 #include <android_native_app_glue.h>
-#include <android/sensor.h>
 #include "CNFGAndroid.h"
 
 #define CNFG_IMPLEMENTATION
@@ -21,20 +20,24 @@ float mountainangle;
 float mountainoffsetx;
 float mountainoffsety;
 
+#ifdef ANDROID_WITH_SENSOR
+#include <android/sensor.h>
 ASensorManager * sm;
 const ASensor * as;
 ASensorEventQueue* aeq;
 ALooper * l;
-
+#endif
 
 void SetupIMU()
 {
+#ifdef ANDROID_WITH_SENSOR
 	sm = ASensorManager_getInstance();
 	as = ASensorManager_getDefaultSensor( sm, ASENSOR_TYPE_GYROSCOPE );
 	l = ALooper_prepare( ALOOPER_PREPARE_ALLOW_NON_CALLBACKS );
 	aeq = ASensorManager_createEventQueue( sm, (ALooper*)&l, 0, 0, 0 ); //XXX??!?! This looks wrong.
 	ASensorEventQueue_enableSensor( aeq, as);
 	printf( "setEvent Rate: %d\n", ASensorEventQueue_setEventRate( aeq, as, 10000 ) );
+#endif
 }
 
 float accx, accy, accz;
@@ -42,6 +45,7 @@ int accs;
 
 void AccCheck()
 {
+#ifdef ANDROID_WITH_SENSOR
 	ASensorEvent evt;
 	do
 	{
@@ -55,6 +59,12 @@ void AccCheck()
 		mountainoffsetx += accx;
 		accs++;
 	} while( 1 );
+#else
+	accx = 0.f;
+	accy = 0.f;
+	accz = 0.f;
+	accs = 0;
+#endif
 }
 
 unsigned frames = 0;
@@ -226,8 +236,12 @@ int main()
 
 	CNFGBGColor = 0x400000;
 	CNFGDialogColor = 0x444444;
+
+#ifdef ANDROID_FULLSCREEN
 	CNFGSetupFullscreen( "Test Bench", 0 );
-	//CNFGSetup( "Test Bench", 0, 0 );
+#else
+	CNFGSetup( "Test Bench", 0, 0 );
+#endif
 
 	for( x = 0; x < HMX; x++ )
 	for( y = 0; y < HMY; y++ )


### PR DESCRIPTION
Some changes for old android version.
If You want maintain separate branch, or something like that.

Disable FULLSCREEN, disable SENSOR,
in rawdraw/CNFGEGLDriver.c in config_attribute_list set EGL_OPENGL_ES2_BIT.
Run on my phone, but up-left rectangle is black.
In log complaint:
`[Mali Err]texture format check error!!!(format:0x1908, internalformat:0x8058, type:0x1401)`