### PR TITLE
Fix #21: Do not render anything if the window has been terminated

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,11 @@ Because we are doing this entirelly in the NDK, with the JNI, we won't have the 
 
 # Departures from regular rawdraw.
 
-Also, above and beyond rawdraw, you *must* implement the following two functions to handle when your apps is suspended or resumed.
+Also, above and beyond rawdraw, you *must* implement the following two functions to handle when your apps is suspended, resumed or has its window terminated.
 
 `void HandleResume();`
 `void HandleSuspend();`
+`void HandleWindowTermination();`
 
 In addition to that, the syntax of `HandleMotion(...)` is different, in that instead of the `mask` variable being a mask, it is simply updating that specific pointer.
 

--- a/test.c
+++ b/test.c
@@ -231,6 +231,11 @@ void HandleResume()
 {
 	suspended = 0;
 }
+
+void HandleWindowTermination() {
+       suspended = 1;
+ }
+
 void Callback( struct CNFADriver * sd, short * out, short * in, int framesp, int framesr )
 {
 	if(suspended) return;


### PR DESCRIPTION
This change depends on https://github.com/cntools/rawdraw/pull/100 and is only here for completion's sake -- `HandleWindowTermination` would be come required.

Updating the `rawdraw` submodule is necessary for this change to do anything.