### PR TITLE
ci: Don't install patcher

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -40,7 +40,6 @@ jobs:
                     "build-tools;29.0.3"
                     "cmake;3.10.2.4988404"
                     "ndk;22.1.7171670"
-                    "patcher;v4"
                     "platform-tools"
                     "platforms;android-30"
                     "tools"


### PR DESCRIPTION
It is unknown what this part of the Android SDK is or what it is needed for, therefore just remove it for now.

Fixes: https://github.com/cnlohr/rawdrawandroid/issues/70