### PR TITLE
Clean AndroidManifest.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,5 +195,5 @@ run : push
 	$(ADB) shell am start -n $(PACKAGENAME)/$(ACTIVITYNAME)
 
 clean :
-	rm -rf temp.apk makecapk.apk makecapk $(APKFILE)
+	rm -rf AndroidManifest.xml temp.apk makecapk.apk makecapk $(APKFILE)
 


### PR DESCRIPTION
Automatically clean AndroidManifest.xml when make clean is called, so that parameters edited inside the makefile reflect in the generated manifest.

Found this issue when I changed the SDK version below SDK 30, resulting in the min-version preventing me from getting this to work on an old kindle. I edited the makefile, called make clean, but the old manifest was preventing a successful install. 