### PR TITLE
optimized application for own computer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,12 +107,15 @@ TARGETS += makecapk/lib/arm64-v8a/lib$(APPNAME).so
 
 CFLAGS_ARM64:=-m64
 CFLAGS_ARM32:=-mfloat-abi=softfp -m32
+#general usage
+CFLAGS_x86:=-march=i686 -mtune=generic -mssse3 -mfpmath=sse -m32
+CFLAGS_x86_64:=-march=x86-64 -msse4.2 -mpopcnt -m64 -mtune=generic
+
 #optimized code for your computer
-CFLAGS_x86 := -march=i686 -mtune=native -m32
-CFLAGS_x86_64 := -march=x86-64 -mtune=native
-#if you want do for intel
-#CFLAGS_x86:=-march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32
-#CFLAGS_x86_64:=-march=x86-64 -msse4.2 -mpopcnt -m64 -mtune=intel
+#if your computer doesnt support 32 bit or 64 bit you can change march as -march=native (i suppose)
+#CFLAGS_x86 := -march=i686 -mtune=native -m32
+#CFLAGS_x86_64 := -march=x86-64 -mtune=native
+
 STOREPASS?=password
 DNAME:="CN=example.com, OU=ID, O=Example, L=Doe, S=John, C=GB"
 KEYSTOREFILE:=my-release-key.keystore

--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,12 @@ TARGETS += makecapk/lib/arm64-v8a/lib$(APPNAME).so
 
 CFLAGS_ARM64:=-m64
 CFLAGS_ARM32:=-mfloat-abi=softfp -m32
-CFLAGS_x86:=-march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32
-CFLAGS_x86_64:=-march=x86-64 -msse4.2 -mpopcnt -m64 -mtune=intel
+#optimized code for your computer
+CFLAGS_x86 := -march=i686 -mtune=native -m32
+CFLAGS_x86_64 := -march=x86-64 -mtune=native
+#if you want do for intel
+#CFLAGS_x86:=-march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32
+#CFLAGS_x86_64:=-march=x86-64 -msse4.2 -mpopcnt -m64 -mtune=intel
 STOREPASS?=password
 DNAME:="CN=example.com, OU=ID, O=Example, L=Doe, S=John, C=GB"
 KEYSTOREFILE:=my-release-key.keystore


### PR DESCRIPTION
according to ChatGPT:
Removed -mssse3, -msse4.2, and -mpopcnt:

    These flags are not needed when using -march or -mtune.
    Both -march=native (if used) and -mtune=native automatically detect and enable relevant instruction sets based on the target CPU.
---------------
Kept -m32 for 32-bit builds (CFLAGS_x86):

    This is required for explicitly targeting 32-bit systems.
--------------
Kept -march for architecture specification:

    -march=i686 ensures compatibility with i686 systems for 32-bit builds.
    -march=x86-64 ensures compatibility with 64-bit x86 systems.
----------------
Why -mtune=native Is Better in This Case

Using -mtune=native ensures that the generated code is tuned for the exact machine where it is compiled, potentially yielding better performance compared to the generic -mtune=intel. -------------

I DID NOT TEST THIS CODE!!!