### PR TITLE
Add support for omnirom beryllium message type

### DIFF
--- a/test.c
+++ b/test.c
@@ -459,7 +459,7 @@ void * JavscriptThread( void * v )
 			env->DeleteLocalRef( envptr, clazzz );
 		}
 
-		if( strcmp( name, "z5" ) == 0 || strcmp( name, "g5" ) == 0 )
+		if( strcmp( name, "z5" ) == 0 || strcmp( name, "g5" ) == 0 || strcmp( name, "iq" ) == 0 )
 		{
 			// Special, Some Androids (notably Meta Quest) use a different private message type.
 			jfieldID mstrf  = env->GetFieldID( envptr, innerClass, "a", "[B" );


### PR DESCRIPTION
OmniROM beryllium running on Pocophone F1, Android 10, has another private message type, 'iq'.
I'm not certain which part of this configuration defines the type, presumably omnirom.

Without this the 'else' branch is taken leading to a crash when trying to access a 'first' pair field for 'innerObj'.

---

### How this fix came about

I have a single android device, a `Pocophone F1` running `omnirom` (beryllium), Android 10.
I was unable to get `rawdrawandroid` to run properly - it would start and almost immediately crash.

**tl;dr** I can confirm that this one change (plus tweaking the `ANDROIDVERSION` in `Makefile` to `29` as I don't have `30` currently installed, but think this is not relevant) was all that I needed to get the example app to run perfectly (afaict).

While attempting to determine the cause, I tried to get debugging with `gdb` working, which led me down an unexpected rabbit hole. One which I have yet to fully resurface from.

I had some time away from this whole project and recently while attempting to debug again, I found the source of the crash; [this line](https://github.com/cnlohr/rawdrawandroid/blob/eaee0d63a3cc3b9097146d0c2e0c5c9fe1b60fc3/test.c#L484) of `test.c`.

I spent some time mistakenly thinking that `iq` (the value of `name` being checked [here](https://github.com/cnlohr/rawdrawandroid/blob/eaee0d63a3cc3b9097146d0c2e0c5c9fe1b60fc3/test.c#L462)) was a java class, but could find no documentation on it, and didn't really understand what was being tested.

Then while exploring recent changes in the `git` history I noticed [commit c4606c](https://github.com/cnlohr/rawdrawandroid/commit/c4606c4ca2fab46cde3f07ccaf9b17653af2a6df), which gave me a bit more insight, such that I decided to test if simply adding `iq` would solve my issue.
And it did.

I would of course be interested to hear if anyone else with a similar setup could corroborate my finding.
And further I'd like to understand where, if anywhere, this stuff is documented, as I feel like I just got lucky.