### PR TITLE
feat: make TARGETS optional so it can be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,10 +110,12 @@ CC_x86_64=$(NDK)/toolchains/llvm/prebuilt/$(OS_NAME)/bin/x86_64-linux-android$(A
 AAPT:=$(BUILD_TOOLS)/aapt
 
 # Which binaries to build? Just comment/uncomment these lines:
-TARGETS += $(BUILD_DIR)/makecapk/lib/arm64-v8a/lib$(APPNAME).so
-TARGETS += $(BUILD_DIR)/makecapk/lib/armeabi-v7a/lib$(APPNAME).so
-TARGETS += $(BUILD_DIR)/makecapk/lib/x86/lib$(APPNAME).so
-TARGETS += $(BUILD_DIR)/makecapk/lib/x86_64/lib$(APPNAME).so
+DEFAULT_TARGETS += $(BUILD_DIR)/makecapk/lib/arm64-v8a/lib$(APPNAME).so
+DEFAULT_TARGETS += $(BUILD_DIR)/makecapk/lib/armeabi-v7a/lib$(APPNAME).so
+DEFAULT_TARGETS += $(BUILD_DIR)/makecapk/lib/x86/lib$(APPNAME).so
+DEFAULT_TARGETS += $(BUILD_DIR)/makecapk/lib/x86_64/lib$(APPNAME).so
+
+TARGETS ?= $(DEFAULT_TARGETS)
 
 CFLAGS_ARM64:=-m64
 CFLAGS_ARM32:=-mfloat-abi=softfp -m32


### PR DESCRIPTION
### Issue

Currently all architectures are built by default (a520051), but the way the TARGETS variable is defined, it doesn't allow it to be overridden by projects using this as a submodule, like [rawdrawandroidexample](https://github.com/cnlohr/rawdrawandroidexample) does.

Trying to override the default targets wont work. Seems like it's just get concatenated with the default ones.

### Solution

Make TARGETS optional so it can be overridden while keep the default value building all architectures by default.